### PR TITLE
fix: ratios for goty schemes

### DIFF
--- a/colour_schemes/main/h2016_goty/chunk0/00E4170B1BDDBEFA.json
+++ b/colour_schemes/main/h2016_goty/chunk0/00E4170B1BDDBEFA.json
@@ -4,6 +4,6 @@
 		"MediumHealthColour": "#FFFFFF",
 		"FullHealthColour": "#FFFFFF",
 		"InfectedColour": "#F8EE2F",
-		"MediumHealthRatio": 0.2
+		"MediumHealthRatio": 0.3
 	}
 }

--- a/colour_schemes/main/h2016_goty_sick/chunk0/00E4170B1BDDBEFA.json
+++ b/colour_schemes/main/h2016_goty_sick/chunk0/00E4170B1BDDBEFA.json
@@ -4,6 +4,6 @@
 		"MediumHealthColour": "#FFFFFF",
 		"FullHealthColour": "#FFFFFF",
 		"InfectedColour": "#A0B000",
-		"MediumHealthRatio": 0.5
+		"MediumHealthRatio": 0.3
 	}
 }


### PR DESCRIPTION
adjusts MediumHealthRatio for the 2016 GOTY scheme to make low health a little more visible
adjusts MediumHealthRatio for the 2016 GOTY and Sick scheme to match